### PR TITLE
fix: use ${project.version} instead of ${version}

### DIFF
--- a/sso-core/pom.xml
+++ b/sso-core/pom.xml
@@ -43,22 +43,22 @@
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-common</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-server-oauth2</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-server-login</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-server-admin</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/sso-server-admin/pom.xml
+++ b/sso-server-admin/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-common</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/sso-server-login/pom.xml
+++ b/sso-server-login/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-common</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/sso-server-oauth2/pom.xml
+++ b/sso-server-oauth2/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.qingyou</groupId>
             <artifactId>sso-common</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
fix: use ${project.version} instead of ${version} in pom.xml

![image](https://github.com/user-attachments/assets/c0912272-3490-492b-b788-4beafbc57604)
